### PR TITLE
Two builders with the same name but in different namespaces  - fixed

### DIFF
--- a/Buildenator/Extensions/GeneratorExecutionContextExtensions.cs
+++ b/Buildenator/Extensions/GeneratorExecutionContextExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Buildenator.Extensions;
+
+public static class GeneratorExecutionContextExtensions
+{
+	private static volatile int _duplicationNumber = 1;
+	public static void AddCsSourceFile(this in GeneratorExecutionContext context, string fileNameWithoutExtension, SourceText sourceText)
+	{
+		try
+		{
+			context.AddSource($"{fileNameWithoutExtension}.cs", sourceText);
+		}
+		catch (System.ArgumentException e) when (e.ParamName == "hintName")
+		{
+			context.AddSource($"{fileNameWithoutExtension}{Interlocked.Increment(ref _duplicationNumber)}.cs", sourceText);
+		}
+	}
+
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## 5.2.2 - 2023-02-04
+
+### Changed
+
+- Fixed problem with having two builders with the same name but in different namespaces, ending up with the filename conflict.
+    - Duplicates will receive numbers at the end of the file names. The incremental is shared among all builders.
+    - Therefore ascending-sorting by names of builders and then by namespaces has been added, to make it deterministic
+
 ## 5.2.1 - 2023-01-12
 
 ### Hotfix

--- a/Tests/Buildenator.IntegrationTests.Source/Builders/Subbuilders/EntityBuilder.cs
+++ b/Tests/Buildenator.IntegrationTests.Source/Builders/Subbuilders/EntityBuilder.cs
@@ -1,0 +1,10 @@
+﻿using Buildenator.Abstraction;
+using Buildenator.IntegrationTests.SharedEntities;
+
+namespace Buildenator.IntegrationTests.Source.Builders.Subbuilders
+{
+    [MakeBuilder(typeof(Entity), defaultStaticCreator: false)]
+    public partial class EntityBuilder
+    {
+    }
+}


### PR DESCRIPTION
- Fixed problem with having two builders with the same name but in different namespaces, ending up with the filename conflict.
    - Duplicates will receive numbers at the end of the file names. The incremental is shared among all builders.
    - Therefore ascending-sorting by names of builders and then by namespaces has been added, to make it deterministic